### PR TITLE
add whois43.publiczone.org

### DIFF
--- a/src/data/whois-servers-extra.json
+++ b/src/data/whois-servers-extra.json
@@ -34,6 +34,17 @@
   "ga": "whois.nic.ga",
   "web.in": "whois.centralnic.com",
   "qzz.io": "whois.digitalplat.org",
+  "int.al": "whois43.publiczone.org",
+  "nyc.mn": "whois43.publiczone.org",
+  "cn.st": "whois43.publiczone.org",
+  "ac.hm": "whois43.publiczone.org",
+  "com.cn.st": "whois43.publiczone.org",
+  "dev.cn.st": "whois43.publiczone.org",
+  "me.cn.st": "whois43.publiczone.org",
+  "edu.cn.st": "whois43.publiczone.org",
+  "net.cn.st": "whois43.publiczone.org",
+  "ngo.cn.st": "whois43.publiczone.org",
+  "org.cn.st": "whois43.publiczone.org",
   "jp": {
     "host": "whois.jprs.jp",
     "query": "{domain}/e\r\n"


### PR DESCRIPTION
Hello!

Could you please add **PublicZone** WHOIS server support to the `whois` client?

**WHOIS server**

```
whois43.publiczone.org
```

**Supported suffixes**

```
.int.al
.nyc.mn
.cn.st
.ac.hm
```

**Example query**

```
$ whois --host whois43.publiczone.org ortech.nyc.mn
```

**Sample response (truncated)**

```
Domain Name: ORTECH.NYC.MN
Registry Domain ID: D4130-PZ
Registrar WHOIS Server: whois.publiczone.org
Registrar URL: https://publiczone.org
Creation Date: 2025-12-28T20:35:08.000Z
Registry Expiry Date: 2124-12-28T20:35:08.000Z
Registrar: Public Zone Registry
```

PublicZone provides subdomains for developers and open-source projects, with domains backed by charitable donations (100% pass-through). More details are available at [https://publiczone.org/](https://publiczone.org).

**Clarification:**
PublicZone's suffixes are NOT gTLDs/ccTLDs, but regular private domains. That's why we are under the PRIVATE section of Mozilla's Public Suffix List: https://publiczone.org/.
